### PR TITLE
pin node to 16 or 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "stylelint-config-gds": "^0.2.0"
       },
       "engines": {
-        "node": ">=16.0.0"
+        "node": "^16 || ^18"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": ">=16.0.0"
+    "node": "^16 || ^18"
   },
   "prototype": {
     "serviceName": "Your service name",


### PR DESCRIPTION
Change copied from govuk-prototype-rig, newer versions of node were causing build failures.

I've done this PR in addition to https://github.com/x-govuk/nhsuk-prototype-rig/pull/1, I'm not certain how these repos are used so no sure if necessary or not.